### PR TITLE
fix(test): update maven version to 3.8.9 for Dockerfile in dubbo-samples native image build

### DIFF
--- a/test/dubbo-test-runner/src/native/Dockerfile
+++ b/test/dubbo-test-runner/src/native/Dockerfile
@@ -20,9 +20,9 @@ RUN yum -y update && \
     yum install -y wget && \
     yum install -y gzip
 
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz && \
-    tar xvf apache-maven-3.9.6-bin.tar.gz -C /opt && \
-    mv /opt/apache-maven-3.9.6/ /opt/maven
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz && \
+    tar xvf apache-maven-3.8.9-bin.tar.gz -C /opt && \
+    mv /opt/apache-maven-3.8.9/ /opt/maven
 
 ENV MAVEN_HOME /opt/maven
 ENV PATH $MAVEN_HOME/bin:$PATH


### PR DESCRIPTION
The official maven 3.9.6 image URL has become unavailable (404). 
Downgrade to 3.8.9 to restore successful Docker image builds.